### PR TITLE
Change isOid to check for consecutive zeroes instead of specific strings

### DIFF
--- a/git.js
+++ b/git.js
@@ -10,8 +10,7 @@ function isOid(string) {
 
     // Not sure the null OID sans "b" is correct, see commit notes
     return (
-        oid !== 'b000000000000000000000000000000000000000' &&
-        oid !== '0000000000000000000000000000000000000000'
+        ! oid.includes('00000000000000000000000000000000000000')
     )
 }
 


### PR DESCRIPTION
Seeing "zero-OIDs" prefixed with 'b' and 'ba'